### PR TITLE
feat: allow users to provide blacklisted words

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A Cryptocurrency BOT built with TypeScript, Node, Telegraf and, CoinGecko API.
 
-A Telegram BOT whichs integrates the Telegram API, CoinGecko API and had a lot of cool features. Please read below:
+A Telegram BOT whichs integrates the Telegram API, CoinGecko API and has a lot of cool features. Please read below:
 
 ## Usage
 
@@ -16,6 +16,10 @@ Set the `CRYPTO_COFFEE_BOT_TOKEN` ENV variable of your Telegram BOT (in your `.e
 
 To start the BOT do the below command:
 
+```console
+npm start
+```
+
 ## BOT commands
 
 ### Price Command
@@ -25,10 +29,6 @@ To start the BOT do the below command:
 `/cbbi` - Displays the CBBI confidence percentage, an indicator to calculate how confident bitcoin has reached its top. More information on the CBBI indicator can be found here: [CBBI website](https://colintalkscrypto.com/cbbi/)
 
 `/twitter` - Please see [Twitter API Integration](#twitter-api-integration)
-
-```console
-npm start
-```
 
 ## Twitter API Integration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cryptocurrency Telegram BOT
 
-A Cryptocurrency BOT built with TypeScript, Node, Telegraf and, CoinGecko API.
+> A Cryptocurrency BOT built with TypeScript, Node, Telegraf and, CoinGecko API.
+
+A Telegram BOT whichs integrates the Telegram API, CoinGecko API and had a lot of cool features. Please read below:
 
 ## Usage
 
@@ -10,13 +12,24 @@ Build the project
 npm run build
 ```
 
-Set the `CRYPTO_COFFEE_BOT_TOKEN` ENV variable of your Telegram BOT (in your `.env` file or command line). You can find your Telegram BOT token via [BotFather](https://telegram.me/BotFather). 
+Set the `CRYPTO_COFFEE_BOT_TOKEN` ENV variable of your Telegram BOT (in your `.env` file or command line). You can find your Telegram BOT token via [BotFather](https://telegram.me/BotFather).
 
 To start the BOT do the below command:
+
+## BOT commands
+
+### Price Command
+
+`/p <coin id>` - The `<coin id>` represents the coin ID e.g. bitcoin and the bot will reply with all of the pricing information. This includes rank, price, 24h high, 24h low, change 24h, volume, market cap, and, ATH.
+
+`/cbbi` - Displays the CBBI confidence percentage, an indicator to calculate how confident bitcoin has reached its top. More information on the CBBI indicator can be found here: [CBBI website](https://colintalkscrypto.com/cbbi/)
+
+`/twitter` - Please see [Twitter API Integration](#twitter-api-integration)
 
 ```console
 npm start
 ```
+
 ## Twitter API Integration
 
 To get started, we need to set a few environment variables for the Twitter API. Within your `.env` file (or wherever you set your ENV variables) set the following:
@@ -46,13 +59,15 @@ Once you have done all of the above, you can start the Twiter stream. Go into yo
 /twitter
 ```
 
-## BOT commands
+## Blacklisted Words
 
-### Price Command
+The BOT allows you blacklist an infinite amount of words to exclude in your Telegram group chat. All you need to do is set the ENV variable `BLACKLISTED_WORDS` in your `.env` file. Example usage below:
 
-`/p <coin id>` - The `<coin id>` represents the coin ID e.g. bitcoin and the bot will reply with all of the pricing information. This includes rank, price, 24h high, 24h low, change 24h, volume, market cap, and, ATH.
+```sh
+BLACKLISTED_WORDS=foo,bar,baz
+```
 
-`/cbbi` - Displays the CBBI confidence percentage, an indicator to calculate how confident bitcoin has reached its top. More information on the CBBI indicator can be found here: [CBBI website](https://colintalkscrypto.com/cbbi/)
+The BOT will look for the words foo, bar or baz in your group chat remove them accordingly.
 
 ### Upcoming
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
     "@types/bad-words": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/bad-words/-/bad-words-3.0.1.tgz",
-      "integrity": "sha512-7la3ZDJG1tlRqySO+pnXycZpacaMEw/iLEm8kc4l+I+jN8KjBfoQVwO6jm98xzXVLrxV8vDrB5TaMoop8sKclQ=="
+      "integrity": "sha512-7la3ZDJG1tlRqySO+pnXycZpacaMEw/iLEm8kc4l+I+jN8KjBfoQVwO6jm98xzXVLrxV8vDrB5TaMoop8sKclQ==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,11 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/bad-words": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bad-words/-/bad-words-3.0.1.tgz",
+      "integrity": "sha512-7la3ZDJG1tlRqySO+pnXycZpacaMEw/iLEm8kc4l+I+jN8KjBfoQVwO6jm98xzXVLrxV8vDrB5TaMoop8sKclQ=="
+    },
     "@types/chai": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
@@ -165,6 +170,21 @@
       "requires": {
         "follow-redirects": "^1.14.4"
       }
+    },
+    "bad-words": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
+      "dev": true,
+      "requires": {
+        "badwords-list": "^1.0.0"
+      }
+    },
+    "badwords-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha1-XphW2/E0gqKVw7CzBK+51M/FxXk=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "devDependencies": {
     "@crypto-coffee/coingecko-api": "^1.0.1-canary-418a47a.0",
+    "@types/bad-words": "^3.0.1",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.19",
@@ -46,7 +47,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@types/bad-words": "^3.0.1",
     "telegraf": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.19",
     "axios": "^0.24.0",
+    "bad-words": "^3.0.4",
     "chai": "^4.3.4",
     "dotenv": "^16.0.0",
     "mocha": "^9.1.2",
@@ -45,6 +46,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
+    "@types/bad-words": "^3.0.1",
     "telegraf": "^4.5.2"
   }
 }

--- a/src/actions/blacklisted-words.ts
+++ b/src/actions/blacklisted-words.ts
@@ -1,0 +1,46 @@
+import Filter from 'bad-words'
+import { Telegraf } from 'telegraf'
+import { splitUserArgs } from '../utils'
+require('dotenv').config()
+
+const { BLACKLISTED_WORDS } = process.env
+const filter = new Filter()
+
+const createWordList = (list: string) => {
+  let wordList: string[] = []
+  try {
+    wordList = splitUserArgs(list)
+  } catch (error) {
+    throw new Error(
+      'Unable to split BLACKLISTED_WORDS ENV. Please make sure it follows the following format: \n BLACKLISTED_WORDS=arg1,arg2,arg3'
+    )
+  }
+
+  return wordList
+}
+
+export const blacklistedWordChecks = (bot: Telegraf) => {
+  if (BLACKLISTED_WORDS) {
+    const wordList: string[] = createWordList(BLACKLISTED_WORDS)
+    filter.addWords(...wordList)
+
+    bot.on('text', async ctx => {
+      const { message_id, text } = ctx.message
+      if (filter.isProfane(text)) {
+        ctx.deleteMessage(message_id)
+      }
+    })
+    bot.on('photo', async ctx => {
+      const { message_id, caption } = ctx.message
+      if (caption && filter.isProfane(caption)) {
+        ctx.deleteMessage(message_id)
+      }
+    })
+    bot.on('video', async ctx => {
+      const { message_id, caption } = ctx.message
+      if (caption && filter.isProfane(caption)) {
+        ctx.deleteMessage(message_id)
+      }
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   markdownWrapper
 } from './utils'
 import { createTwitterClient, startStream } from './actions/twitter'
+import { blacklistedWordChecks } from './actions/blacklisted-words'
 
 const { CRYPTO_COFFEE_BOT_TOKEN } = process.env
 const bot = new Telegraf(CRYPTO_COFFEE_BOT_TOKEN as string)
@@ -70,5 +71,7 @@ bot.command('/twitter', async ctx => {
     ctx.reply('Twitter stream has already started...')
   }
 })
+
+blacklistedWordChecks(bot)
 
 bot.launch()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,3 +121,7 @@ export const fetchCBBIIndicator = async () => {
   `
   return botMessage
 }
+
+export const splitUserArgs = (args: string) => {
+  return args.split(',')
+}


### PR DESCRIPTION
This feature allows users to provide a list of words that the bot will remove if present in their Telegram group. 

Users will enable a new ENV variable: `BLACKLISTED_WORDS` that will take a comma delimited list of words for example: 

```sh
BLACKLISTED_WORDS=foo,bar,baz
```
The BOT will check on every message to see if these words exist, if they do the BOT will remove the message.

Closes issue: https://github.com/Zidious/crypto-telegrambot/issues/29